### PR TITLE
Arreglo metrica memoria + set metrics

### DIFF
--- a/main/sensors/tasks/task_sensor_performance.c
+++ b/main/sensors/tasks/task_sensor_performance.c
@@ -40,7 +40,12 @@ void task_sensor_performance(void *args) {
         sensor_data[1] = esp_get_minimum_free_heap_size();
         // ESP_LOGI(MESH_TAG, "Memory usage: %d bytes", esp_get_free_heap_size() - esp_get_minimum_free_heap_size());
         // we divide by 512KB because the heap has that size instead of 4MB
-        sensor_data[2] = (esp_get_free_heap_size() - esp_get_minimum_free_heap_size()) / 512;
+        //sensor_data[2] = (esp_get_free_heap_size() - esp_get_minimum_free_heap_size()) / 512;
+
+        // Heap size is 512kb
+        uint32_t heap_size = 512 * 1024;
+        // Percentage of free memory = (free memory / heap size) * 100
+        sensor_data[2] = (uint32_t)((1-(esp_get_free_heap_size() / (float) heap_size)) * 100);
 
         // Sending for each sensor metric the message value to the topic
 

--- a/main/tasks_config/tasks_config.c
+++ b/main/tasks_config/tasks_config.c
@@ -317,10 +317,10 @@ char ** get_sensor_metrics_by_task_id(int id) {
     if (sensor_metrics == NULL) {
         return NULL;
     }
-
     char ** sensor_metrics_ = (char **) malloc(sizeof(char *) * 5);
     int i = 0;
     while (sensor_metrics != NULL) {
+
         // check if we need more memory for the array
         if (i > 5) {
             sensor_metrics_ = (char **) realloc(sensor_metrics_, sizeof(char *) * i + 1);
@@ -411,7 +411,23 @@ void add_sensor_metric(char* task_name, char * metric_type, char * metric_unit) 
     sensor_metric->metric_unit = (char *) malloc(sizeof(char) * strlen(metric_unit) + 1);
     strcpy(sensor_metric->metric_unit, metric_unit);
     sensor_metric->metric_unit[strlen(metric_unit)] = '\0';
-    sensor_metric->next = ret_task_mapping->sensor_metrics;
-    ret_task_mapping->sensor_metrics = sensor_metric;
+
+    if (ret_task_mapping->sensor_metrics == NULL) {
+        // First metric, add the current metric to the set
+        ret_task_mapping->sensor_metrics = sensor_metric;
+        sensor_metric->next = NULL;
+    } else {
+        // Is not the first metric, add the current metric to the last position
+        SensorMetric_t *sensor_metrics_ = ret_task_mapping->sensor_metrics;
+        while (sensor_metrics_->next != NULL) {
+            sensor_metrics_ = sensor_metrics_->next;
+        }
+        sensor_metrics_->next = sensor_metric;
+        sensor_metric->next = NULL;
+    }
+
+    //sensor_metric->next = ret_task_mapping->sensor_metrics;
+    //ret_task_mapping->sensor_metrics = sensor_metric;
+   
     ESP_LOGI("[add_sensor_metric]", "Adding sensor metric: %s (unit: %s) to task name: %s", metric_type, metric_unit, task_name);
 }


### PR DESCRIPTION
 - Parece que el cálculo de la memoria en terminos porcentuales estaba mal calculada.
 - Al agregar métricas a una task, la metrica se agregaba al principio en vez de al final, invirtiendo el orden esperado del as métricas